### PR TITLE
Config option to not record raw data

### DIFF
--- a/com.aware.plugin.ambient_noise/src/main/java/com/aware/plugin/ambient_noise/AudioAnalyser.java
+++ b/com.aware.plugin.ambient_noise/src/main/java/com/aware/plugin/ambient_noise/AudioAnalyser.java
@@ -83,9 +83,11 @@ public class AudioAnalyser extends IntentService {
         data.put(Provider.AmbientNoise_Data.RMS, sound_rms);
         data.put(Provider.AmbientNoise_Data.IS_SILENT, is_silent);
 
-        ByteBuffer byteBuff = ByteBuffer.allocate(2 * buffer_size);
-        for (Short a : audio_data) byteBuff.putShort(a);
-        data.put(Provider.AmbientNoise_Data.RAW, byteBuff.array());
+        if (!Aware.getSetting(getApplicationContext(), Settings.PLUGIN_AMBIENT_NOISE_NO_RAW).equals("true")) {
+            ByteBuffer byteBuff = ByteBuffer.allocate(2 * buffer_size);
+            for (Short a : audio_data) byteBuff.putShort(a);
+            data.put(Provider.AmbientNoise_Data.RAW, byteBuff.array());
+        }
 
         data.put(Provider.AmbientNoise_Data.SILENCE_THRESHOLD, Aware.getSetting(getApplicationContext(), Settings.PLUGIN_AMBIENT_NOISE_SILENCE_THRESHOLD));
 

--- a/com.aware.plugin.ambient_noise/src/main/java/com/aware/plugin/ambient_noise/Settings.java
+++ b/com.aware.plugin.ambient_noise/src/main/java/com/aware/plugin/ambient_noise/Settings.java
@@ -33,6 +33,11 @@ public class Settings extends PreferenceActivity implements OnSharedPreferenceCh
      */
     public static final String PLUGIN_AMBIENT_NOISE_SILENCE_THRESHOLD = "plugin_ambient_noise_silence_threshold";
 
+    /**
+     * Do not include the raw sample in the data that is sent.
+     */
+    public static final String PLUGIN_AMBIENT_NOISE_NO_RAW = "plugin_ambient_noise_no_raw";
+
     private static CheckBoxPreference active;
     private static EditTextPreference frequency, listen, silence;
 

--- a/com.aware.plugin.ambient_noise/src/main/res/xml/preferences.xml
+++ b/com.aware.plugin.ambient_noise/src/main/res/xml/preferences.xml
@@ -34,4 +34,11 @@
         android:summary="Silent below 50dB"
         android:title="How loud is silence?" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="plugin_ambient_noise_no_raw"
+        android:persistent="true"
+        android:summary="If true only signal analysis is saved"
+        android:title="Don't save raw audio" />
+
 </PreferenceScreen>


### PR DESCRIPTION
This makes a configuration option to not save the raw audio data.  This is needed because one our our experiments doesn't have permission to collect raw audio data.

A tester reports this works with our server.